### PR TITLE
Extend PgClientConfig options with fetchTypes

### DIFF
--- a/.changeset/sixty-windows-add.md
+++ b/.changeset/sixty-windows-add.md
@@ -1,0 +1,5 @@
+---
+"@sqlfx/pg": patch
+---
+
+add fetchTypes to pg options

--- a/packages/pg/src/index.ts
+++ b/packages/pg/src/index.ts
@@ -70,6 +70,7 @@ export interface PgClientConfig {
   readonly transformResultNames?: (str: string) => string
   readonly transformQueryNames?: (str: string) => string
   readonly transformJson?: boolean
+  readonly fetchTypes?: boolean
 }
 
 const escape = Statement.defaultEscape('"')
@@ -119,6 +120,7 @@ export const make = (
       password: options.password
         ? ConfigSecret.value(options.password)
         : undefined,
+      fetch_types: options.fetchTypes
     }
 
     const client = options.url


### PR DESCRIPTION
Could it be possible to expose the `fetch_types` prop via PGClientConfig? 

