### PR TITLE
pass debug option to pg driver

### DIFF
--- a/.changeset/small-cheetahs-develop.md
+++ b/.changeset/small-cheetahs-develop.md
@@ -1,0 +1,5 @@
+---
+"@sqlfx/pg": patch
+---
+
+add debug option to pg config

--- a/packages/pg/src/index.ts
+++ b/packages/pg/src/index.ts
@@ -71,6 +71,8 @@ export interface PgClientConfig {
   readonly transformQueryNames?: (str: string) => string
   readonly transformJson?: boolean
   readonly fetchTypes?: boolean
+
+  readonly debug?: postgres.Options<{}>["debug"]
 }
 
 const escape = Statement.defaultEscape('"')
@@ -119,6 +121,7 @@ export const make = (
       username: options.username,
       password: options.password ? Secret.value(options.password) : undefined,
       fetch_types: options.fetchTypes,
+      debug: options.debug,
     }
 
     const client = options.url


### PR DESCRIPTION
hi, recently I found myself needing the debug driver option in pg, and I had to fork the layer file to be able to pass it, I don't know about other driver params, but I think this one is worth passing from config