### PR TITLE
add mysql2 package

### DIFF
--- a/.changeset/calm-flowers-begin.md
+++ b/.changeset/calm-flowers-begin.md
@@ -1,0 +1,10 @@
+---
+"@sqlfx/mysql2": patch
+"@sqlfx/sqlite": patch
+"@sqlfx/mssql": patch
+"@sqlfx/mysql": patch
+"@sqlfx/sql": patch
+"@sqlfx/pg": patch
+---
+
+fix tag identifiers

--- a/.changeset/lovely-emus-hammer.md
+++ b/.changeset/lovely-emus-hammer.md
@@ -1,0 +1,5 @@
+---
+"@sqlfx/mysql2": minor
+---
+
+initial version

--- a/packages/mssql/src/internal/client.ts
+++ b/packages/mssql/src/internal/client.ts
@@ -25,7 +25,7 @@ import type { DataType } from "tedious/lib/data-type.js"
 import type { ParameterOptions } from "tedious/lib/request.js"
 
 /** @internal */
-export const tag = GenericTag<MssqlClient>("@services/tag")
+export const tag = GenericTag<MssqlClient>("sqlfx/MssqlClient")
 
 interface MssqlConnection extends Connection {
   readonly call: (

--- a/packages/mysql/src/index.ts
+++ b/packages/mysql/src/index.ts
@@ -41,7 +41,7 @@ export interface MysqlClient extends Client.Client {
  * @category tag
  * @since 1.0.0
  */
-export const tag = GenericTag<MysqlClient>("@services/tag")
+export const tag = GenericTag<MysqlClient>("sqlfx/mysql/MysqlClient")
 
 /**
  * @category constructor

--- a/packages/mysql2/CHANGELOG.md
+++ b/packages/mysql2/CHANGELOG.md
@@ -1,0 +1,1 @@
+# @sqlfx/mysql2

--- a/packages/mysql2/LICENSE
+++ b/packages/mysql2/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2023-present The Contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/mysql2/README.md
+++ b/packages/mysql2/README.md
@@ -1,0 +1,5 @@
+# @sqlfx/mysql2
+
+A MySQL client for Effect-TS.
+
+See https://tim-smart.github.io/sqlfx/ for more information.

--- a/packages/mysql2/docgen.json
+++ b/packages/mysql2/docgen.json
@@ -1,0 +1,28 @@
+{
+  "exclude": ["src/internal/**/*.ts"],
+  "theme": "mikearnaldi/just-the-docs",
+  "parseCompilerOptions": {
+    "noEmit": true,
+    "strict": true,
+    "target": "es2015",
+    "lib": ["es2015"],
+    "paths": {
+      "@sqlfx/sql": ["../sql/src/index.ts"],
+      "@sqlfx/sql/*": ["../sql/src/*"],
+      "@sqlfx/pg": ["./src/index.ts"],
+      "@sqlfx/pg/*": ["./src/*"]
+    }
+  },
+  "examplesCompilerOptions": {
+    "noEmit": true,
+    "strict": true,
+    "target": "es2015",
+    "lib": ["es2015"],
+    "paths": {
+      "@sqlfx/sql": ["../sql/src/index.ts"],
+      "@sqlfx/sql/*": ["../sql/src/*"],
+      "@sqlfx/pg": ["./src/index.ts"],
+      "@sqlfx/pg/*": ["./src/*"]
+    }
+  }
+}

--- a/packages/mysql2/examples/migrations/00001_create people.ts
+++ b/packages/mysql2/examples/migrations/00001_create people.ts
@@ -1,0 +1,15 @@
+import * as Sql from "@sqlfx/mysql2"
+import * as Effect from "effect/Effect"
+
+export default Effect.flatMap(
+  Sql.tag,
+  sql =>
+    sql`
+      CREATE TABLE people (
+        id INT NOT NULL AUTO_INCREMENT,
+        name VARCHAR(255) NOT NULL,
+        created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+        PRIMARY KEY (id)
+      )
+    `,
+)

--- a/packages/mysql2/examples/migrations/_schema.sql
+++ b/packages/mysql2/examples/migrations/_schema.sql
@@ -1,0 +1,16 @@
+CREATE TABLE `people` (
+  `id` int(11) NOT NULL AUTO_INCREMENT,
+  `name` varchar(255) NOT NULL,
+  `created_at` timestamp NOT NULL DEFAULT current_timestamp(),
+  PRIMARY KEY (`id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
+
+CREATE TABLE `sqlfx_migrations` (
+  `migration_id` int(10) unsigned NOT NULL,
+  `created_at` timestamp NOT NULL DEFAULT current_timestamp(),
+  `name` varchar(255) NOT NULL,
+  PRIMARY KEY (`migration_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
+
+INSERT INTO `sqlfx_migrations` VALUES
+(1,'2023-05-20 01:03:50','create people');

--- a/packages/mysql2/examples/migrator.ts
+++ b/packages/mysql2/examples/migrator.ts
@@ -1,0 +1,49 @@
+/// <reference types="node" />
+
+import * as Sql from "@sqlfx/mysql2"
+import * as Migrator from "@sqlfx/mysql2/Migrator"
+import * as Config from "effect/Config"
+import * as Effect from "effect/Effect"
+import { pipe } from "effect/Function"
+import * as Layer from "effect/Layer"
+import * as Secret from "effect/Secret"
+import { fileURLToPath } from "node:url"
+
+const program = Effect.gen(function* (_) {
+  const sql = yield* _(Sql.tag)
+
+  const [{ id }] = yield* _(
+    Effect.zipRight(
+      sql`INSERT INTO people (name) VALUES ('John')`,
+      sql<{ id: number }>`SELECT LAST_INSERT_ID() AS id`,
+    ),
+  )
+
+  const person = yield* _(sql`SELECT * FROM people WHERE id = ${id}`)
+  console.log(person[0])
+})
+
+const SqlLive = Sql.makeLayer({
+  database: Config.succeed("effect_dev"),
+  username: Config.succeed("effect"),
+  password: Config.succeed(Secret.fromString("password")),
+  transformQueryNames: Config.succeed(Sql.transform.camelToSnake),
+  transformResultNames: Config.succeed(Sql.transform.snakeToCamel),
+})
+
+const MigratorLive = Layer.provide(
+  Migrator.makeLayer({
+    loader: Migrator.fromDisk(
+      `${fileURLToPath(new URL(".", import.meta.url))}/migrations`,
+    ),
+    schemaDirectory: "examples/migrations",
+  }),
+  SqlLive,
+)
+
+pipe(
+  program,
+  Effect.provide(Layer.mergeAll(SqlLive, MigratorLive)),
+  Effect.tapErrorCause(Effect.logError),
+  Effect.runFork,
+)

--- a/packages/mysql2/examples/stream.ts
+++ b/packages/mysql2/examples/stream.ts
@@ -1,0 +1,34 @@
+import * as Sql from "@sqlfx/mysql2"
+import * as Config from "effect/Config"
+import * as Effect from "effect/Effect"
+import { pipe } from "effect/Function"
+import * as Secret from "effect/Secret"
+import * as Stream from "effect/Stream"
+
+const program = Effect.gen(function* (_) {
+  const sql = yield* _(Sql.tag)
+  yield* _(
+    sql`INSERT INTO people (name) VALUES ('John')`.pipe(Effect.repeatN(100)),
+  )
+  const results = yield* _(
+    sql`SELECT * FROM people`.stream,
+    Stream.tap(_ => Effect.logInfo(_).pipe(Effect.delay("10 millis"))),
+    Stream.runCollect,
+  )
+  console.log(results)
+})
+
+const SqlLive = Sql.makeLayer({
+  database: Config.succeed("effect_dev"),
+  username: Config.succeed("effect"),
+  password: Config.succeed(Secret.fromString("password")),
+  transformQueryNames: Config.succeed(Sql.transform.camelToSnake),
+  transformResultNames: Config.succeed(Sql.transform.snakeToCamel),
+})
+
+pipe(
+  program,
+  Effect.provide(SqlLive),
+  Effect.tapErrorCause(Effect.logError),
+  Effect.runFork,
+)

--- a/packages/mysql2/examples/transaction.ts
+++ b/packages/mysql2/examples/transaction.ts
@@ -1,0 +1,29 @@
+import * as Sql from "@sqlfx/mysql2"
+import * as Config from "effect/Config"
+import * as Effect from "effect/Effect"
+import { pipe } from "effect/Function"
+import * as Secret from "effect/Secret"
+
+const SqlLive = Sql.makeLayer({
+  database: Config.succeed("effect_dev"),
+  username: Config.succeed("effect"),
+  password: Config.succeed(Secret.fromString("password")),
+  transformQueryNames: Config.succeed(Sql.transform.camelToSnake),
+  transformResultNames: Config.succeed(Sql.transform.snakeToCamel),
+})
+
+const program = Effect.gen(function* (_) {
+  const sql = yield* _(Sql.tag)
+  const result = yield* _(
+    sql.withTransaction(sql`SELECT * FROM people LIMIT 1`),
+    sql.withTransaction,
+  )
+  console.log(result)
+})
+
+pipe(
+  program,
+  Effect.provide(SqlLive),
+  Effect.tapErrorCause(Effect.logError),
+  Effect.runFork,
+)

--- a/packages/mysql2/package.json
+++ b/packages/mysql2/package.json
@@ -1,0 +1,39 @@
+{
+  "name": "@sqlfx/mysql2",
+  "version": "0.0.0",
+  "description": "",
+  "publishConfig": {
+    "access": "public",
+    "directory": "dist"
+  },
+  "type": "module",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/tim-smart/sqlfx.git"
+  },
+  "author": "Tim Smart <hello@timsmart.co>",
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/tim-smart/sqlfx/issues"
+  },
+  "homepage": "https://github.com/tim-smart/sqlfx",
+  "scripts": {
+    "build": "pnpm build-esm && pnpm build-cjs && pnpm build-annotate && build-utils pack-v2",
+    "build-esm": "tsc -b tsconfig.build.json",
+    "build-cjs": "babel build/esm --plugins @babel/transform-export-namespace-from --plugins @babel/transform-modules-commonjs --out-dir build/cjs --source-maps",
+    "build-annotate": "babel build --plugins annotate-pure-calls --out-dir build --source-maps"
+  },
+  "keywords": [],
+  "sideEffects": false,
+  "dependencies": {
+    "@sqlfx/sql": "workspace:^",
+    "mysql2": "^3.9.3"
+  },
+  "devDependencies": {
+    "@effect/schema": "^0.64.4",
+    "effect": "^2.4.7"
+  },
+  "peerDependencies": {
+    "effect": "^2.4.7"
+  }
+}

--- a/packages/mysql2/src/Error.ts
+++ b/packages/mysql2/src/Error.ts
@@ -1,0 +1,4 @@
+/**
+ * @since 1.0.0
+ */
+export * from "@sqlfx/sql/Error"

--- a/packages/mysql2/src/Migrator.ts
+++ b/packages/mysql2/src/Migrator.ts
@@ -1,0 +1,134 @@
+/**
+ * @since 1.0.0
+ */
+/// <reference types="node" />
+
+import type { SqlError } from "@sqlfx/sql/Error"
+import * as _ from "@sqlfx/sql/Migrator"
+import { fromDisk } from "@sqlfx/sql/Migrator/Node"
+import * as Effect from "effect/Effect"
+import * as Layer from "effect/Layer"
+import * as Secret from "effect/Secret"
+import { execFile } from "node:child_process"
+import * as NFS from "node:fs"
+import * as Path from "node:path"
+import * as Sql from "./index.js"
+
+const { fromBabelGlob, fromGlob } = _
+
+export {
+  /**
+   * @category loader
+   * @since 1.0.0
+   */
+  fromBabelGlob,
+  /**
+   * @category loader
+   * @since 1.0.0
+   */
+  fromDisk,
+  /**
+   * @category loader
+   * @since 1.0.0
+   */
+  fromGlob,
+}
+
+/**
+ * @category constructor
+ * @since 1.0.0
+ */
+export const run: (
+  options: _.MigratorOptions,
+) => Effect.Effect<
+  ReadonlyArray<readonly [id: number, name: string]>,
+  SqlError | _.MigrationError,
+  Sql.MysqlClient
+> = _.make({
+  getClient: Sql.tag,
+  ensureTable(sql, table) {
+    return sql`
+      CREATE TABLE IF NOT EXISTS ${sql(table)} (
+        migration_id INTEGER UNSIGNED NOT NULL,
+        created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+        name VARCHAR(255) NOT NULL,
+        PRIMARY KEY (migration_id)
+      )
+    `
+  },
+  dumpSchema(sql, path, table) {
+    const mysqlDump = (args: Array<string>) =>
+      Effect.map(
+        Effect.async<string, _.MigrationError>(resume => {
+          execFile(
+            "mysqldump",
+            [
+              ...(sql.config.username ? ["-u", sql.config.username] : []),
+              ...(sql.config.database ? [sql.config.database] : []),
+              "--skip-comments",
+              "--compact",
+              ...args,
+            ],
+            {
+              env: {
+                PATH: process.env.PATH,
+                MYSQL_HOST: sql.config.host,
+                MYSQL_TCP_PORT: sql.config.port?.toString(),
+                MYSQL_PWD: sql.config.password
+                  ? Secret.value(sql.config.password)
+                  : undefined,
+              },
+            },
+            (error, sql) => {
+              if (error) {
+                resume(
+                  Effect.fail(
+                    _.MigrationError({
+                      reason: "failed",
+                      message: `Failed to dump schema: ${error}`,
+                    }),
+                  ),
+                )
+              } else {
+                resume(Effect.succeed(sql))
+              }
+            },
+          )
+        }),
+        _ =>
+          _.replace(/^\/\*.*$/gm, "")
+            .replace(/\n{2,}/gm, "\n\n")
+            .trim(),
+      )
+
+    const dumpSchema = mysqlDump(["--no-data"])
+
+    const dumpMigrations = mysqlDump(["--no-create-info", "--tables", table])
+
+    const dumpAll = Effect.map(
+      Effect.all([dumpSchema, dumpMigrations], { concurrency: 2 }),
+      ([schema, migrations]) => schema + "\n\n" + migrations,
+    )
+
+    const dumpFile = (path: string) =>
+      Effect.flatMap(dumpAll, sql =>
+        Effect.sync(() => {
+          NFS.mkdirSync(Path.dirname(path), {
+            recursive: true,
+          })
+          NFS.writeFileSync(path, sql)
+        }),
+      )
+
+    return dumpFile(path)
+  },
+})
+
+/**
+ * @category constructor
+ * @since 1.0.0
+ */
+export const makeLayer = (
+  options: _.MigratorOptions,
+): Layer.Layer<never, _.MigrationError | SqlError, Sql.MysqlClient> =>
+  Layer.effectDiscard(run(options))

--- a/packages/mysql2/src/index.ts
+++ b/packages/mysql2/src/index.ts
@@ -42,7 +42,7 @@ export interface MysqlClient extends Client.Client {
  * @category tag
  * @since 1.0.0
  */
-export const tag = GenericTag<MysqlClient>("@services/tag")
+export const tag = GenericTag<MysqlClient>("sqlfx/mysql2/MysqlClient")
 
 /**
  * @category constructor

--- a/packages/mysql2/src/index.ts
+++ b/packages/mysql2/src/index.ts
@@ -1,0 +1,239 @@
+/**
+ * @since 1.0.0
+ */
+import * as Client from "@sqlfx/sql/Client"
+import type { Connection } from "@sqlfx/sql/Connection"
+import { SqlError } from "@sqlfx/sql/Error"
+import * as Statement from "@sqlfx/sql/Statement"
+import { asyncPauseResume } from "@sqlfx/sql/Stream"
+import * as transform from "@sqlfx/sql/Transform"
+import * as Chunk from "effect/Chunk"
+import * as Config from "effect/Config"
+import type { ConfigError } from "effect/ConfigError"
+import { GenericTag } from "effect/Context"
+import * as Duration from "effect/Duration"
+import * as Effect from "effect/Effect"
+import { pipe } from "effect/Function"
+import * as Layer from "effect/Layer"
+import type { Scope } from "effect/Scope"
+import * as Secret from "effect/Secret"
+import * as Stream from "effect/Stream"
+import type * as MysqlSync from "mysql2"
+import * as Mysql from "mysql2/promise"
+
+export {
+  /**
+   * Column renaming helpers.
+   *
+   * @since 1.0.0
+   */
+  transform,
+}
+
+/**
+ * @category model
+ * @since 1.0.0
+ */
+export interface MysqlClient extends Client.Client {
+  readonly config: MysqlClientConfig
+}
+
+/**
+ * @category tag
+ * @since 1.0.0
+ */
+export const tag = GenericTag<MysqlClient>("@services/tag")
+
+/**
+ * @category constructor
+ * @since 1.0.0
+ */
+export interface MysqlClientConfig {
+  /**
+   * Connection URI. Setting this will override the other connection options
+   */
+  readonly url?: Secret.Secret
+
+  readonly host?: string
+  readonly port?: number
+  readonly database?: string
+  readonly username?: string
+  readonly password?: Secret.Secret
+
+  readonly maxConnections?: number
+  readonly connectionTTL?: Duration.DurationInput
+
+  readonly poolConfig?: Mysql.PoolOptions
+
+  readonly transformResultNames?: (str: string) => string
+  readonly transformQueryNames?: (str: string) => string
+}
+
+const escape = Statement.defaultEscape("`")
+
+/**
+ * @category constructor
+ * @since 1.0.0
+ */
+export const make = (
+  options: MysqlClientConfig,
+): Effect.Effect<MysqlClient, never, Scope> =>
+  Effect.gen(function* (_) {
+    const compiler = makeCompiler(options.transformQueryNames)
+
+    const transformRows = Client.defaultTransforms(
+      options.transformResultNames!,
+    ).array
+
+    class ConnectionImpl implements Connection {
+      constructor(private readonly conn: Mysql.PoolConnection | Mysql.Pool) {}
+
+      private run(
+        sql: string,
+        values?: ReadonlyArray<any>,
+        transform = true,
+        rowsAsArray = false,
+        method: "execute" | "query" = "execute",
+      ) {
+        const result = Effect.tryPromise({
+          try: () =>
+            this.conn[method]<Array<Mysql.RowDataPacket>>(
+              { sql, rowsAsArray },
+              values,
+            ),
+          catch: error => SqlError((error as any).message, error),
+        }).pipe(
+          Effect.map(
+            ([rowDataPackets]) => rowDataPackets as ReadonlyArray<any>,
+          ),
+        )
+
+        if (transform && !rowsAsArray && options.transformResultNames) {
+          return Effect.map(result, transformRows)
+        }
+
+        return result
+      }
+
+      execute(statement: Statement.Statement<unknown>) {
+        const [sql, params] = compiler.compile(statement)
+        return this.run(sql, params)
+      }
+      executeWithoutTransform(statement: Statement.Statement<unknown>) {
+        const [sql, params] = compiler.compile(statement)
+        return this.run(sql, params, false)
+      }
+      executeValues(statement: Statement.Statement<unknown>) {
+        const [sql, params] = compiler.compile(statement)
+        return this.run(sql, params, true, true)
+      }
+      executeRaw(sql: string, params?: ReadonlyArray<Statement.Primitive>) {
+        return this.run(sql, params, true, false, "query")
+      }
+      executeStream(statement: Statement.Statement<unknown>) {
+        const [sql, params] = compiler.compile(statement)
+
+        const stream =
+          "connection" in this.conn
+            ? queryStream(this.conn, sql, params)
+            : pipe(
+                acquireConn,
+                Effect.map(conn => queryStream(conn, sql, params)),
+                Stream.unwrapScoped,
+              )
+
+        return options.transformResultNames
+          ? Stream.mapChunks(stream, _ =>
+              Chunk.unsafeFromArray(
+                transformRows(Chunk.toReadonlyArray(_) as Array<object>),
+              ),
+            )
+          : stream
+      }
+    }
+
+    const pool = options.url
+      ? Mysql.createPool(Secret.value(options.url))
+      : Mysql.createPool({
+          ...(options.poolConfig ?? {}),
+          host: options.host,
+          port: options.port,
+          database: options.database,
+          user: options.username,
+          password: options.password
+            ? Secret.value(options.password)
+            : undefined,
+          connectionLimit: options.maxConnections,
+          idleTimeout: options.connectionTTL
+            ? Duration.toMillis(options.connectionTTL)
+            : undefined,
+        })
+
+    yield* _(Effect.addFinalizer(() => Effect.promise(() => pool.end())))
+
+    const poolConnection = new ConnectionImpl(pool)
+
+    const acquireConn = Effect.acquireRelease(
+      Effect.tryPromise({
+        try: () => pool.getConnection(),
+        catch: error => SqlError((error as any).message, error),
+      }),
+      conn => Effect.sync(() => conn.release()),
+    )
+
+    const transactionAcquirer = Effect.map(
+      acquireConn,
+      conn => new ConnectionImpl(conn),
+    )
+
+    return Object.assign(
+      Client.make({
+        acquirer: Effect.succeed(poolConnection),
+        transactionAcquirer,
+        compiler,
+      }),
+      { config: options },
+    )
+  })
+
+/**
+ * @category constructor
+ * @since 1.0.0
+ */
+export const makeLayer: (
+  config: Config.Config.Wrap<MysqlClientConfig>,
+) => Layer.Layer<MysqlClient, ConfigError> = (
+  config: Config.Config.Wrap<MysqlClientConfig>,
+) => Layer.scoped(tag, Effect.flatMap(Config.unwrap(config), make))
+
+/**
+ * @category constructor
+ * @since 1.0.0
+ */
+export const makeCompiler = (transform?: (_: string) => string) =>
+  Statement.makeCompiler(
+    _ => `?`,
+    transform ? _ => escape(transform(_)) : escape,
+    () => ["", []],
+    () => ["", []],
+  )
+
+function queryStream(
+  conn: Mysql.PoolConnection,
+  sql: string,
+  params?: ReadonlyArray<any>,
+) {
+  return asyncPauseResume<never, SqlError, any>(emit => {
+    const query = ((conn as any).connection as MysqlSync.PoolConnection)
+      .query(sql, params)
+      .stream()
+    query.on("error", error => emit.fail(SqlError(error.message, error)))
+    query.on("data", emit.single)
+    query.on("end", () => emit.end())
+    return {
+      onInterrupt: Effect.sync(() => query.destroy()),
+      onPause: Effect.sync(() => query.pause()),
+      onResume: Effect.sync(() => query.resume()),
+    }
+  })
+}

--- a/packages/mysql2/src/tsconfig.json
+++ b/packages/mysql2/src/tsconfig.json
@@ -1,0 +1,38 @@
+{
+  "compilerOptions": {
+    "moduleDetection": "force",
+    "downlevelIteration": true,
+    "resolveJsonModule": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "emitDecoratorMetadata": true,
+    "experimentalDecorators": true,
+    "preserveSymlinks": true,
+    "moduleResolution": "NodeNext",
+    "lib": ["ES2021", "DOM", "DOM.Iterable"],
+    "sourceMap": true,
+    "strict": true,
+    "noImplicitReturns": false,
+    "noUnusedLocals": true,
+    "noUnusedParameters": false,
+    "noFallthroughCasesInSwitch": true,
+    "noEmitOnError": false,
+    "allowJs": false,
+    "checkJs": false,
+    "forceConsistentCasingInFileNames": true,
+    "stripInternal": true,
+    "noImplicitAny": true,
+    "noImplicitThis": true,
+    "noUncheckedIndexedAccess": false,
+    "strictNullChecks": true,
+    "target": "ES2021",
+    "module": "NodeNext",
+    "incremental": true,
+    "removeComments": false,
+    "paths": {
+      "@sqlfx/mysql2": ["./index.ts"],
+      "@sqlfx/mysql2/*": ["./*.ts"]
+    }
+  },
+  "include": ["**/*"]
+}

--- a/packages/mysql2/test/index.test.ts
+++ b/packages/mysql2/test/index.test.ts
@@ -1,0 +1,7 @@
+import { assert, describe, it } from "vitest"
+
+describe("mysql2", () => {
+  it("should work", () => {
+    assert.ok(true)
+  })
+})

--- a/packages/mysql2/tsconfig.build.json
+++ b/packages/mysql2/tsconfig.build.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./tsconfig.src.json",
+  "compilerOptions": {
+    "tsBuildInfoFile": ".tsbuildinfo/build.tsbuildinfo",
+    "outDir": "build/esm",
+    "declarationDir": "build/dts",
+    "stripInternal": true
+  },
+  "references": [{ "path": "../sql" }]
+}

--- a/packages/mysql2/tsconfig.examples.json
+++ b/packages/mysql2/tsconfig.examples.json
@@ -1,0 +1,16 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "include": [
+    "examples"
+  ],
+  "references": [
+    {
+      "path": "tsconfig.build.json"
+    }
+  ],
+  "compilerOptions": {
+    "tsBuildInfoFile": ".tsbuildinfo/examples.tsbuildinfo",
+    "rootDir": "examples",
+    "noEmit": true
+  }
+}

--- a/packages/mysql2/tsconfig.json
+++ b/packages/mysql2/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "references": [
+    {
+      "path": "tsconfig.src.json"
+    },
+    {
+      "path": "tsconfig.test.json"
+    },
+    {
+      "path": "tsconfig.examples.json"
+    }
+  ]
+}

--- a/packages/mysql2/tsconfig.src.json
+++ b/packages/mysql2/tsconfig.src.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "include": ["src"],
+  "compilerOptions": {
+    "tsBuildInfoFile": ".tsbuildinfo/src.tsbuildinfo",
+    "rootDir": "src",
+    "outDir": "build/src"
+  },
+  "references": [{ "path": "../sql" }]
+}

--- a/packages/mysql2/tsconfig.test.json
+++ b/packages/mysql2/tsconfig.test.json
@@ -1,0 +1,16 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "include": [
+    "test",
+  ],
+  "references": [
+    {
+      "path": "tsconfig.src.json"
+    },
+  ],
+  "compilerOptions": {
+    "tsBuildInfoFile": ".tsbuildinfo/test.tsbuildinfo",
+    "rootDir": "test",
+    "noEmit": true
+  }
+}

--- a/packages/mysql2/vitest.config.ts
+++ b/packages/mysql2/vitest.config.ts
@@ -1,0 +1,15 @@
+import * as path from "path"
+import { defineConfig } from "vitest/config"
+
+export default defineConfig({
+  test: {
+    include: ["./test/**/*.test.ts"],
+  },
+  resolve: {
+    alias: {
+      "@sqlfx/sql": path.join(__dirname, "../sql/src"),
+      "@sqlfx/mysql2/test": path.join(__dirname, "test"),
+      "@sqlfx/mysql2": path.join(__dirname, "src"),
+    },
+  },
+})

--- a/packages/pg/src/index.ts
+++ b/packages/pg/src/index.ts
@@ -44,7 +44,7 @@ export interface PgClient extends Client.Client {
  * @category tag
  * @since 1.0.0
  */
-export const tag = GenericTag<PgClient>("@services/tag")
+export const tag = GenericTag<PgClient>("sqlfx/pg/PgClient")
 
 /**
  * @category constructor

--- a/packages/sql/src/Connection.ts
+++ b/packages/sql/src/Connection.ts
@@ -50,7 +50,7 @@ export namespace Connection {
  * @category tag
  * @since 1.0.0
  */
-export const Connection = GenericTag<Connection>("@services/Connection")
+export const Connection = GenericTag<Connection>("sqlfx/sql/Connection")
 
 /**
  * @category model

--- a/packages/sql/src/internal/client.ts
+++ b/packages/sql/src/internal/client.ts
@@ -19,7 +19,7 @@ import * as Statement from "../Statement.js"
 /** @internal */
 export const TransactionConn = GenericTag<
   readonly [conn: Connection, counter: number]
->("@services/TransactionConn")
+>("sqlfx/sql/TransactionConn")
 
 /** @internal */
 export function make({

--- a/packages/sqlite/src/internal/client.ts
+++ b/packages/sqlite/src/internal/client.ts
@@ -3,7 +3,7 @@ import * as Statement from "@sqlfx/sql/Statement"
 import type { SqliteClient } from "../Client.js"
 
 /** @internal */
-export const tag = GenericTag<SqliteClient>("@services/tag")
+export const tag = GenericTag<SqliteClient>("sqlfx/sqlite/SqliteClient")
 
 const escape = Statement.defaultEscape('"')
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -120,7 +120,24 @@ importers:
         version: link:../sql/dist
       mariadb:
         specifier: ^3.2.3
-        version: 3.2.3
+        version: 3.3.0
+    devDependencies:
+      '@effect/schema':
+        specifier: ^0.64.4
+        version: 0.64.4(effect@2.4.7)(fast-check@3.16.0)
+      effect:
+        specifier: ^2.4.7
+        version: 2.4.7
+    publishDirectory: dist
+
+  packages/mysql2:
+    dependencies:
+      '@sqlfx/sql':
+        specifier: workspace:^
+        version: link:../sql/dist
+      mysql2:
+        specifier: ^3.9.3
+        version: 3.9.3
     devDependencies:
       '@effect/schema':
         specifier: ^0.64.4
@@ -3619,8 +3636,8 @@ packages:
     resolution: {integrity: sha512-/kYRxGDLWzHOB7q+wtSUQlFrtcdUccpfy+X+9iMBpHK8QLLhx2wIPYuS5DYtR9Wa/YlZAbIovy7qVdB1Aq6Lyw==}
     dev: true
 
-  /@types/geojson@7946.0.13:
-    resolution: {integrity: sha512-bmrNrgKMOhM3WsafmbGmC+6dsF2Z308vLFsQ3a/bT8X8Sv5clVYpPars/UPq+sAaJP+5OoLAYgwbkS5QEJdLUQ==}
+  /@types/geojson@7946.0.14:
+    resolution: {integrity: sha512-WCfD5Ht3ZesJUsONdhvm84dmzWOiOzOAqOncN0++w0lBw1o8OuDNJF2McvvCef/yBqb/HYRahp1BYtODFQ8bRg==}
     dev: false
 
   /@types/glob@7.1.3:
@@ -3686,10 +3703,6 @@ packages:
   /@types/node@12.20.55:
     resolution: {integrity: sha512-J8xLz7q2OFulZ2cyGTLE1TbbZcjpno7FaN6zdJNrgAdrJ+DZzh/uFR6YrTb4C+nXakvud8Q4+rbhoIWlYQbUFQ==}
     dev: true
-
-  /@types/node@17.0.45:
-    resolution: {integrity: sha512-w+tIMs3rq2afQdsPJlODhoUEKzFP1ayaoyl1CcnwtIlsVe7K7bA1NGm4s3PraqTLlXnbIN84zuBlxBWo1u9BLw==}
-    dev: false
 
   /@types/node@20.11.28:
     resolution: {integrity: sha512-M/GPWVS2wLkSkNHVeLkrF2fD5Lx5UC4PxA0uZcKc6QqbIQUJyW1jVjueJYi1z8n0I5PxYrtpnPnWglE+y9A0KA==}
@@ -6834,6 +6847,12 @@ packages:
     resolution: {integrity: sha512-xckBUXyTIqT97tq2x2AMb+g163b5JFysYk0x4qxNFwbfQkmNZoiRHb6sPzI9/QV33WeuvVYBUIiD4NzNIyqaRQ==}
     dev: true
 
+  /generate-function@2.3.1:
+    resolution: {integrity: sha512-eeB5GfMNeevm/GRYq20ShmsaGcmI81kIX2K9XQx5miC8KdHaC6Jm0qQ8ZNeGOi7wYB8OsdxKs+Y2oVuTFuVwKQ==}
+    dependencies:
+      is-property: 1.0.2
+    dev: false
+
   /gensync@1.0.0-beta.2:
     resolution: {integrity: sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==}
     engines: {node: '>=6.9.0'}
@@ -7622,6 +7641,10 @@ packages:
       isobject: 3.0.1
     dev: true
 
+  /is-property@1.0.2:
+    resolution: {integrity: sha512-Ks/IoX00TtClbGQr4TWXemAnktAQvYB7HzcCxDGqEZU6oCmb2INHuOoKxbtR+HFkmYWBKv/dOZtGRiAjDhj92g==}
+    dev: false
+
   /is-regex@1.1.4:
     resolution: {integrity: sha512-kvRdxDsxZjhzUX07ZnLydzS1TU/TJlTUHHY4YLL87e37oUA49DfkLqgy+VjFocowy29cKvcSiu+kIv728jTTVg==}
     engines: {node: '>= 0.4'}
@@ -8404,6 +8427,10 @@ packages:
       yargs: 15.4.1
     dev: true
 
+  /long@5.2.3:
+    resolution: {integrity: sha512-lcHwpNoggQTObv5apGNCTdJrO69eHOZMi4BNC+rTLER8iHAqGrUVeLh/irVIM7zTw2bOXA8T6uNPeujwOLg/2Q==}
+    dev: false
+
   /loose-envify@1.4.0:
     resolution: {integrity: sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==}
     hasBin: true
@@ -8420,6 +8447,12 @@ packages:
   /lru-cache@10.1.0:
     resolution: {integrity: sha512-/1clY/ui8CzjKFyjdvwPWJUYKiFVXG2I2cY0ssG7h4+hwk+XOIX7ZSG9Q7TW8TW3Kp3BUSqgFWBLgL4PJ+Blag==}
     engines: {node: 14 || >=16.14}
+    dev: true
+
+  /lru-cache@10.2.0:
+    resolution: {integrity: sha512-2bIM8x+VAf6JT4bKAljS1qUWgMsqZRPGJS6FSahIMPVvctcNhyVp7AJu7quxOW9jwkryBReKZY5tY5JYv2n/7Q==}
+    engines: {node: 14 || >=16.14}
+    dev: false
 
   /lru-cache@4.1.5:
     resolution: {integrity: sha512-sWZlbEP2OsHNkXrMl5GYk/jKk70MBng6UU4YI/qGDYbgf6YbP4EvmqISbXCoJiRKs+1bSpFHVgQxvJ17F2li5g==}
@@ -8439,6 +8472,16 @@ packages:
     engines: {node: '>=10'}
     dependencies:
       yallist: 4.0.0
+
+  /lru-cache@7.18.3:
+    resolution: {integrity: sha512-jumlc0BIUrS3qJGgIkWZsyfAM7NCWiBcCDhnd+3NNM5KbBmLTgHVfWBcg6W+rLUsIpzpERPsvwUP7CckAQSOoA==}
+    engines: {node: '>=12'}
+    dev: false
+
+  /lru-cache@8.0.5:
+    resolution: {integrity: sha512-MhWWlVnuab1RG5/zMRRcVGXZLCXrZTgfwMikgzCegsPnG62yDQo5JnqKkrK4jO5iKqDAZGItAqN5CtKBCBWRUA==}
+    engines: {node: '>=16.14'}
+    dev: false
 
   /madge@6.1.0(typescript@5.4.2):
     resolution: {integrity: sha512-irWhT5RpFOc6lkzGHKLihonCVgM0YtfNUh4IrFeW3EqHpnt/JHUG3z26j8PeJEktCGB4tmGOOOJi1Rl/ACWucQ==}
@@ -8523,15 +8566,15 @@ packages:
     engines: {node: '>=8'}
     dev: true
 
-  /mariadb@3.2.3:
-    resolution: {integrity: sha512-Hyc1ehdUJwzvvzcLU2juZS528wJ6oE8pUlpgY0BAOdpKWcdN1motuugi5lC3jkpCkFpyNknHG7Yg66KASl3aPg==}
-    engines: {node: '>= 12'}
+  /mariadb@3.3.0:
+    resolution: {integrity: sha512-sAL4bJgbfCAtXcE8bXI+NAMzVaPNkIU8hRZUXYfgNFoWB9U57G3XQiMeCx/A6IrS6y7kGwBLylrwgsZQ8kUYlw==}
+    engines: {node: '>= 14'}
     dependencies:
-      '@types/geojson': 7946.0.13
-      '@types/node': 17.0.45
+      '@types/geojson': 7946.0.14
+      '@types/node': 20.11.28
       denque: 2.1.0
       iconv-lite: 0.6.3
-      lru-cache: 10.1.0
+      lru-cache: 10.2.0
     dev: false
 
   /markdown-link@0.1.1:
@@ -9066,6 +9109,20 @@ packages:
     dev: true
     optional: true
 
+  /mysql2@3.9.3:
+    resolution: {integrity: sha512-+ZaoF0llESUy7BffccHG+urErHcWPZ/WuzYAA9TEeLaDYyke3/3D+VQDzK9xzRnXpd0eMtRf0WNOeo4Q1Baung==}
+    engines: {node: '>= 8.0'}
+    dependencies:
+      denque: 2.1.0
+      generate-function: 2.3.1
+      iconv-lite: 0.6.3
+      long: 5.2.3
+      lru-cache: 8.0.5
+      named-placeholders: 1.1.3
+      seq-queue: 0.0.5
+      sqlstring: 2.3.3
+    dev: false
+
   /mz@2.7.0:
     resolution: {integrity: sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==}
     dependencies:
@@ -9073,6 +9130,13 @@ packages:
       object-assign: 4.1.1
       thenify-all: 1.6.0
     dev: true
+
+  /named-placeholders@1.1.3:
+    resolution: {integrity: sha512-eLoBxg6wE/rZkJPhU/xRX1WTpkFEwDJEN96oxFrTsqBdbT5ec295Q+CoHrL9IT0DipqKhmGcaZmwOt8OON5x1w==}
+    engines: {node: '>=12.0.0'}
+    dependencies:
+      lru-cache: 7.18.3
+    dev: false
 
   /nanoid@3.3.6:
     resolution: {integrity: sha512-BGcqMMJuToF7i1rt+2PWSNVnWIkGCU78jBG3RxO/bZlnZPK2Cmi2QaffxGO/2RvWi9sL+FAiRiXMgsyxQ1DIDA==}
@@ -10580,6 +10644,10 @@ packages:
       - supports-color
     dev: true
 
+  /seq-queue@0.0.5:
+    resolution: {integrity: sha512-hr3Wtp/GZIc/6DAGPDcV4/9WoZhjrkXsi5B/07QgX8tsdc6ilr7BFM6PM6rbdAX1kFSDYeZGLipIZZKyQP0O5Q==}
+    dev: false
+
   /serialize-error@2.1.0:
     resolution: {integrity: sha512-ghgmKt5o4Tly5yEG/UJp8qTd0AN7Xalw4XBtDEKP655B699qMEtra1WlXeE6WIvdEG481JvRxULKsInq/iNysw==}
     engines: {node: '>=0.10.0'}
@@ -10852,6 +10920,11 @@ packages:
 
   /sprintf-js@1.1.3:
     resolution: {integrity: sha512-Oo+0REFV59/rz3gfJNKQiBlwfHaSESl1pcGyABQsnnIfWOFt6JNj5gCog2U6MLZ//IGYD+nA8nI+mTShREReaA==}
+    dev: false
+
+  /sqlstring@2.3.3:
+    resolution: {integrity: sha512-qC9iz2FlN7DQl3+wjwn3802RTyjCx7sDvfQEXchwa6CWOx07/WVfh91gBmQ9fahw8snwGEWU3xGzOt4tFyHLxg==}
+    engines: {node: '>= 0.6'}
     dev: false
 
   /ssri@8.0.1:

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -56,6 +56,11 @@
       "@sqlfx/mysql/*": ["./packages/mysql/src/*.ts"],
       "@sqlfx/mysql": ["./packages/mysql/src/index.ts"],
 
+      "@sqlfx/mysql2/test/*": ["./packages/mysql2/test/*.ts"],
+      "@sqlfx/mysql2/examples/*": ["./packages/mysql2/examples/*.ts"],
+      "@sqlfx/mysql2/*": ["./packages/mysql2/src/*.ts"],
+      "@sqlfx/mysql2": ["./packages/mysql2/src/index.ts"],
+
       "@sqlfx/sqlite/test/*": ["./packages/sqlite/test/*.ts"],
       "@sqlfx/sqlite/examples/*": ["./packages/sqlite/examples/*.ts"],
       "@sqlfx/sqlite/*": ["./packages/sqlite/src/*.ts"],

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -5,6 +5,7 @@
     { "path": "packages/pg/tsconfig.build.json" },
     { "path": "packages/mssql/tsconfig.build.json" },
     { "path": "packages/mysql/tsconfig.build.json" },
+    { "path": "packages/mysql2/tsconfig.build.json" },
     { "path": "packages/sqlite/tsconfig.build.json" }
   ]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,6 +5,7 @@
     { "path": "packages/pg" },
     { "path": "packages/mssql" },
     { "path": "packages/mysql" },
+    { "path": "packages/mysql2" },
     { "path": "packages/sqlite" }
   ]
 }


### PR DESCRIPTION
Add an additional mysql package based upon the [node-mysql2](https://github.com/sidorares/node-mysql2) package, copying directly from the existing mariadb-based package. We have experienced issues with the mariadb pool implementation and would prefer to use node-mysql2. If the naming is awkward, we might consider adding suffixes to the implementation packages, ie mysql-mariadb and mysql-mysql2, or simply replacing the mariadb implementation.

The node-mysql2 promise-based connection API does not expose query streams, so we are forced to access the private, underlying connection instance.

I have successfully run the examples against a local mysql instance.